### PR TITLE
Dvef-120 remove set framerate

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -55,7 +55,6 @@ app.on('window-all-close', () => {
 
 app.on('ready', () => {
   mainWindow = new BrowserWindow({width: 1280, height: 720});
-  mainWindow.webContents.setFrameRate(30);
   
   ipcMain.on('conferenceJoined', (e) => {
     console.error('conference joined');


### PR DESCRIPTION
According to docs contents.setFrameRate(fps) sets the frame rate to the specified number only If offscreen rendering is enabled. Since voxeet-io does not have it set, it should be ok to remove it.
 