### PR TITLE
Electron package upgrade to support m1 macs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -116,7 +116,7 @@
     "copy-webpack-plugin": "^4.2.0",
     "cross-env": "^7.0.2",
     "css-loader": "^2.1.1",
-    "electron": "^5.0.7",
+    "electron": "^11.0.0-beta.1",
     "electron-builder": "^22.6.0",
     "electron-builder-squirrel-windows": "^22.6.1",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",


### PR DESCRIPTION
Apple Silicon Support: https://www.electronjs.org/blog/apple-silicon


The current electron version of ^5.0.7 is not supported on Apple M1 chips.

Error during yarn install:
```
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
[-/3] ⡀ waiting...
[2/3] ⡀ fsevents
error /Users/jay/Code/voxeet-io-web/frontend/node_modules/electron: Command failed.
Exit code: 1
Command: node install.js
Arguments: 
Directory: /Users/jay/Code/voxeet-io-web/frontend/node_modules/electron
Output:
Downloading tmp-28180-0-electron-v5.0.13-darwin-arm64.zip
Error: GET https://github.com/electron/electron/releases/download/v5.0.13/electron-v5.0.13-darwin-arm64.zip returned 404
/Users/jay/Code/voxeet-io-web/frontend/node_modules/electron/install.js:49
  throw err
  ^

Error: Failed to find Electron v5.0.13 for darwin-arm64 at https://github.com/electron/electron/releases/download/v5.0.13/electron-v5.0.13-darwin-arm64.zip
    at Request.<anonymous> (/Users/jay/Code/voxeet-io-web/frontend/node_modules/nugget/index.js:169:61)
    at Request.emit (events.js:400:28)
    at Request.onRequestResponse (/Users/jay/Code/voxeet-io-web/frontend/node_modules/request/request.js:1059:10)
    at ClientRequest.emit (events.js:400:28)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:647:27)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:127:17)
    at TLSSocket.socketOnData (_http_client.js:515:22)
    at TLSSocket.emit (events.js:400:28)
    at addChunk (internal/streams/readable.js:293:12)
    at readableAddChunk (internal/streams/readable.js:267:9)
```

Upgrading it to 11.0.0-beta.1 worked