### PR TITLE
CCU-242 Build app with SDK versions without DVWC

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -130,11 +130,11 @@ module.exports = {
       "./public/manifest.json",
     ]),
     new CopyWebpackPlugin([
-      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/dvwc_impl.wasm" },
-      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-dvwc-worker.js" },
-      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-worklet.js" },
-      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-dvwc-worker.js.map" },
-      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-worklet.js.map" },
+      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/dvwc_impl.wasm", noErrorOnMissing: true },
+      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-dvwc-worker.js", noErrorOnMissing: true },
+      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-worklet.js", noErrorOnMissing: true },
+      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-dvwc-worker.js.map", noErrorOnMissing: true },
+      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-worklet.js.map", noErrorOnMissing: true },
     ]),
     new HtmlWebpackPlugin({
       inject: true,


### PR DESCRIPTION
Stop CI from failing when DVWC integration files are missing - allow it to build with different non-WASM SDK versions