### PR TITLE
CCU-242 Upgrade copy-webpack-plugin to fix CI for DVWC-supporting SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,27 @@ jobs:
           buildoptions: "--pull"
           tags: "${{ env.GITHUB_REF_SLUG }}"
 
+<<<<<<< HEAD
   build_frontend_hotfix-3_0_docker_image:
+=======
+  build_frontend_master_production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rlespinasse/github-slug-action@v3.x
+      - name: build and publish frontend Docker container for master - production Web SDK
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        with:
+          name: voxeet/voxeet-io-web
+          dockerfile: Dockerfile
+          workdir: frontend
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          buildoptions: "--pull"
+          tags: "${{ env.GITHUB_REF_SLUG }}"
+
+  build_frontend_beta:
+>>>>>>> Bump frontend container node version from 12 to 14
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -91,6 +111,7 @@ jobs:
           UX_KIT_DIST_TAG: develop
           CUSTOM_REGISTRY_URL: ${{ secrets.CODEARTIFACT_NPM_SNAPSHOTS_REPOSITORY_URL }}
         with:
+<<<<<<< HEAD
           node-version: "16.9.1"
       - run: |
           npm config set registry=${{ secrets.CODEARTIFACT_NPM_SNAPSHOTS_REPOSITORY_TOKEN }}
@@ -98,6 +119,17 @@ jobs:
           npm config set always-auth true
           yarn add -E @voxeet/voxeet-web-sdk@${{ env.WEB_SDK_DIST_TAG }}
           yarn add -E @voxeet/react-components@${{ env.UX_KIT_DIST_TAG }}
+=======
+          name: voxeet-io-web
+          dockerfile: Dockerfile
+          workdir: frontend
+          username: ${{ steps.ecr.outputs.username }}
+          password: ${{ steps.ecr.outputs.password }}
+          registry: ${{ steps.ecr.outputs.registry }}
+          buildargs: CUSTOM_REGISTRY_URL,CUSTOM_REGISTRY_TOKEN,WEB_SDK_DIST_TAG,UX_KIT_DIST_TAG
+          buildoptions: "--pull"
+          tags: "${{ env.WEB_SDK_DIST_TAG }}"
+>>>>>>> Bump frontend container node version from 12 to 14
 
           yarn install
           yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,27 +25,7 @@ jobs:
           buildoptions: "--pull"
           tags: "${{ env.GITHUB_REF_SLUG }}"
 
-<<<<<<< HEAD
   build_frontend_hotfix-3_0_docker_image:
-=======
-  build_frontend_master_production:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: rlespinasse/github-slug-action@v3.x
-      - name: build and publish frontend Docker container for master - production Web SDK
-        uses: elgohr/Publish-Docker-Github-Action@2.22
-        with:
-          name: voxeet/voxeet-io-web
-          dockerfile: Dockerfile
-          workdir: frontend
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          buildoptions: "--pull"
-          tags: "${{ env.GITHUB_REF_SLUG }}"
-
-  build_frontend_beta:
->>>>>>> Bump frontend container node version from 12 to 14
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -111,7 +91,6 @@ jobs:
           UX_KIT_DIST_TAG: develop
           CUSTOM_REGISTRY_URL: ${{ secrets.CODEARTIFACT_NPM_SNAPSHOTS_REPOSITORY_URL }}
         with:
-<<<<<<< HEAD
           node-version: "16.9.1"
       - run: |
           npm config set registry=${{ secrets.CODEARTIFACT_NPM_SNAPSHOTS_REPOSITORY_TOKEN }}
@@ -119,17 +98,6 @@ jobs:
           npm config set always-auth true
           yarn add -E @voxeet/voxeet-web-sdk@${{ env.WEB_SDK_DIST_TAG }}
           yarn add -E @voxeet/react-components@${{ env.UX_KIT_DIST_TAG }}
-=======
-          name: voxeet-io-web
-          dockerfile: Dockerfile
-          workdir: frontend
-          username: ${{ steps.ecr.outputs.username }}
-          password: ${{ steps.ecr.outputs.password }}
-          registry: ${{ steps.ecr.outputs.registry }}
-          buildargs: CUSTOM_REGISTRY_URL,CUSTOM_REGISTRY_TOKEN,WEB_SDK_DIST_TAG,UX_KIT_DIST_TAG
-          buildoptions: "--pull"
-          tags: "${{ env.WEB_SDK_DIST_TAG }}"
->>>>>>> Bump frontend container node version from 12 to 14
 
           yarn install
           yarn build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -113,7 +113,7 @@
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.5",
-    "copy-webpack-plugin": "^4.2.0",
+    "copy-webpack-plugin": "^6.0.0",
     "cross-env": "^7.0.2",
     "css-loader": "^2.1.1",
     "electron": "^5.0.7",

--- a/frontend/webpack.config.electron.prod.js
+++ b/frontend/webpack.config.electron.prod.js
@@ -121,13 +121,13 @@ module.exports = {
       },
     }),
     new PrettierPlugin(),
-    new CopyWebpackPlugin([
+    new CopyWebpackPlugin({ patterns: [
       { from: "./src/static", ignore: ["*.html"] },
       // "./public/index.html",
       "./public/favicon.ico",
       "./public/icon.png",
       "./public/manifest.json",
-    ]),
+    ]}),
     new HtmlWebpackPlugin({
       // inject: 'head',
       cache: false,

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -125,17 +125,17 @@ module.exports = {
         AUTH_SERVER: JSON.stringify(AUTH_SERVER),
       },
     }),
-    new CopyWebpackPlugin([
-      { from: "./src/static", ignore: ["*.html"] },
+    new CopyWebpackPlugin({ patterns: [
+      { from: "./src/static", globOptions: { ignore: ["**/*.html"] }},
       "./public/manifest.json",
-    ]),
-    new CopyWebpackPlugin([
+    ]}),
+    new CopyWebpackPlugin({ patterns: [
       { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/dvwc_impl.wasm", noErrorOnMissing: true },
       { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-dvwc-worker.js", noErrorOnMissing: true },
       { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-worklet.js", noErrorOnMissing: true },
       { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-dvwc-worker.js.map", noErrorOnMissing: true },
       { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-worklet.js.map", noErrorOnMissing: true },
-    ]),
+    ]}),
     new HtmlWebpackPlugin({
       inject: true,
       template: "./public/index.html",

--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -119,15 +119,15 @@ module.exports = {
       },
     }),
     new PrettierPlugin(),
-    new CopyWebpackPlugin([
-      { from: "./src/static", ignore: ["*.html"] },
+    new CopyWebpackPlugin({ patterns: [
+      { from: "./src/static", globOptions: { ignore: ["**/*.html"] } },
       "./public/manifest.json",
-    ]),
-    new CopyWebpackPlugin([
-      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/dvwc_impl.wasm", noErrorOnMissing: true },
+    ]}),
+    new CopyWebpackPlugin({ patterns: [
+      { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/dvwc_impl.wasm", noErrorOnMissing: true, },
       { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-dvwc-worker.js", noErrorOnMissing: true },
       { from: "./node_modules/@voxeet/voxeet-web-sdk/dist/voxeet-worklet.js", noErrorOnMissing: true },
-    ]),
+    ]}),
     new HtmlWebpackPlugin({
       inject: true,
       template: "./public/index.html",


### PR DESCRIPTION
To support noErrorOnMissing flag copy-webpack-plugin needs to be upgraded to v6.0.0. Some syntax changes are required for this.